### PR TITLE
fix: Update angular naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@
 
 Список фреймворков:
 - [ ] [ReactJS](https://facebook.github.io/react/)
-- [ ] [AngularJS](https://angular.io/)
+- [ ] [Angular](https://angular.io/)
 - [ ] [Backbone](http://backbonejs.org/)
 - [ ] [Ember](http://emberjs.com/)
 


### PR DESCRIPTION
Изменение небольшое, но принципиальное, т.к. AngularJS-ом называют фреймворк версии 1.x.
Со второй версии фреймворка из названия был убран суффикс JS.